### PR TITLE
feat: implement HOVER/CLICK modes; safe delete shift; skip empty cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,79 @@
-# Swing Grid Task
+### Swing Grid Task
 
-A small Java Swing application (grid of cells) implemented as a coding task.  
-It includes basic keyboard navigation and mouse interaction (hover, click).
+# A small Java Swing app showing a grid of cells.
+Implements hover highlight, delete-on-click (in one mode), and click-to-select (in another mode), plus simple keyboard navigation.
 
-## How to Run
+Features (what’s implemented)
 
-### Using an IDE (IntelliJ IDEA / Eclipse)
-1. Open the project as a Java project.
-2. Run the class `Launcher` (it contains the `main` method).
+Two modes (toggle with SPACE):
+
+а) HOVER: hover highlights a cell (green). Left-click deletes the hovered cell.
+
+б) CLICK: Left-click selects a cell and updates the header/title accordingly.
+
+Only one green highlight at a time. Hover overrides keyboard selection.
+
+Empty cells are inert: they don’t highlight, can’t be selected, and clicks on them do nothing.
+
+Column shift on delete: when a cell is deleted, all cells below it in the same column move up, and the bottom cell of that column becomes empty.
+
+Keyboard: ← / → move the selection skipping empty cells.
+
+Header/Title shows the currently selected cell’s text (or "-" if none/empty).
+
+Config validation: throws IllegalArgumentException if ROWS*COLS < PANELS_COUNT, non-positive grid sizes, or invalid highlightIndex.
+
+Controls
+
+Mouse
+
+Hover: highlights non-empty cell (HOVER mode).
+
+Left-click:
+
+HOVER mode: delete hovered cell (column shifts up).
+
+CLICK mode: select cell and update header/title.
+
+Keyboard
+
+← / →: move selection to the previous/next non-empty cell.
+
+SPACE: toggle mode (HOVER ↔ CLICK).
+
+If arrow keys don’t respond, click the grid once to ensure it has focus.
+
+Configuration
+
+Edit constants in MyContainer:
+
+PANELS_COUNT — number of cells to render.
+
+COLS, ROWS — grid dimensions.
+
+The app validates that ROWS * COLS >= PANELS_COUNT. Otherwise it throws:
+
+IllegalArgumentException: Invalid configuration: ROWS*COLS ... < PANELS_COUNT ...
+
+How to Run
+Using an IDE (IntelliJ IDEA / Eclipse)
+
+Open the project as a Java project.
+
+Run the class Launcher (it contains the main method).
+
+Project Structure (example)
+src/
+test/
+Launcher.java
+MainWindow.java
+MyContainer.java
+SelectionMode.java
+
+Next steps
+
+- Unit tests for grid model and delete/shift behavior.
+
+- Extract a simple GridModel (data + logic) separate from Swing UI.
+
+- Strategy pattern for selection behaviors (HOVER vs CLICK).

--- a/src/test/Launcher.java
+++ b/src/test/Launcher.java
@@ -8,7 +8,7 @@ public class Launcher {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new SwingTemplate();  // Let the constructor do the job
+                new MainWindow();  // Let the constructor do the job
             }
         });
     }

--- a/src/test/MainWindow.java
+++ b/src/test/MainWindow.java
@@ -1,0 +1,28 @@
+package test;
+
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Main application window.
+ * Sets up the frame and places the game container inside.
+ */
+
+
+public class MainWindow extends JFrame {
+    public static final int WINDOW_WIDTH = 600;
+    public static final int WINDOW_HEIGHT = 600;
+    MyContainer container;
+
+    public MainWindow() {
+        Container cp = this.getContentPane();
+
+        container = new MyContainer(WINDOW_WIDTH, WINDOW_HEIGHT, this);
+        cp.add(container);
+
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+        setVisible(true);
+    }
+}

--- a/src/test/MyContainer.java
+++ b/src/test/MyContainer.java
@@ -1,143 +1,203 @@
 package test;
 
-import java.awt.*;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
-
+import javax.swing.border.Border;
 
 
 public class MyContainer extends JPanel {
-	public static final int PANELS_COUNT = 13;
-	private final int COLS = 4;
-	private final int ROWS = 4;
-	private SelectionMode selectionMode = SelectionMode.HOVER;
+    public static final int PANELS_COUNT = 15;
+    private static final int COLS = 4;
+    private static final int ROWS = 4;
 
-	private JLabel modeLabel;
-	int highlightIndex=6;
+    private static final Border BORDER_BLUE = BorderFactory.createLineBorder(Color.blue);
+    private static final Border BORDER_GREEN = BorderFactory.createLineBorder(Color.green, 3);
 
-	JLabel[] panels=new JLabel[PANELS_COUNT];
-	SwingTemplate st;
+    private SelectionMode selectionMode = SelectionMode.HOVER;
 
-	public MyContainer(int windowWidth, int windowHeight, SwingTemplate st) {
+    private JLabel modeLabel;
+    int highlightIndex = 6;
 
-		this.setSize(windowWidth, windowHeight);
-		this.st = st;
-		this.setLayout(new BorderLayout());
-		modeLabel = new JLabel("Mode: " + selectionMode, SwingConstants.CENTER);
+    JLabel[] panels = new JLabel[PANELS_COUNT];
+    private final MainWindow window;
 
-		this.add(modeLabel, BorderLayout.NORTH);
+    public MyContainer(int windowWidth, int windowHeight, MainWindow window) {
 
+        this.window = window;
+        validateConfig();
+        this.setSize(windowWidth, windowHeight);
+        this.setLayout(new BorderLayout());
 
-		JPanel gridPanel = new JPanel(new GridLayout(ROWS, COLS));
+        modeLabel = new JLabel("Mode: " + selectionMode + " To change press SPACE", SwingConstants.CENTER);
+        this.add(modeLabel, BorderLayout.NORTH);
 
-		Font labelFont = this.getFont();
-		Font myFont = new Font(labelFont.getName(), Font.PLAIN, 30);
+        JPanel gridPanel = new JPanel(new GridLayout(ROWS, COLS));
+        setupKeyListener();
+        Font labelFont = this.getFont();
+        Font myFont = new Font(labelFont.getName(), Font.PLAIN, 30);
 
-		for (int i = 0; i < PANELS_COUNT; i++) {
-			panels[i] = new JLabel();
-			panels[i].setFont(myFont);
-			panels[i].setText(String.valueOf(i));
-			panels[i].setHorizontalAlignment(SwingConstants.CENTER);
-			panels[i].setBorder(BorderFactory.createLineBorder(Color.blue));
-			panels[i].addMouseListener(createSelectionListener(i));
-			gridPanel.add(panels[i]);
+        for (int i = 0; i < PANELS_COUNT; i++) {
+            panels[i] = new JLabel();
+            panels[i].setFont(myFont);
+            panels[i].setText(String.valueOf(i));
+            panels[i].setHorizontalAlignment(SwingConstants.CENTER);
+            panels[i].setBorder(BorderFactory.createLineBorder(Color.blue));
+            panels[i].addMouseListener(createSelectionListener(i));
+            gridPanel.add(panels[i]);
 
-		}
-		this.add(gridPanel, BorderLayout.CENTER);
-		updateView();
-	}
-  
-	private MouseAdapter createSelectionListener(int index) {
-		return new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				if (selectionMode == SelectionMode.CLICK && SwingUtilities.isLeftMouseButton(e)) {
-					highlightIndex = index;
-					updateView();
-				}
-				else{
-					highlightIndex = index;
-					deleteAt(index);
-					updateView();
-				}
-			}
+        }
+        this.add(gridPanel, BorderLayout.CENTER);
+        updateView();
+    }
 
-			@Override
-			public void mouseEntered(MouseEvent e) {
-				if (selectionMode == SelectionMode.HOVER) {
-					highlightIndex = index;
-					updateView();
-				}
-			}
+    private MouseAdapter createSelectionListener(int index) {
+        return new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (isEmptyCell(index)) return;
+                if (selectionMode == SelectionMode.CLICK && SwingUtilities.isLeftMouseButton(e)) {
+                    highlightIndex = index;
+                    updateView();
+                } else if (selectionMode == SelectionMode.HOVER && SwingUtilities.isLeftMouseButton(e)) {
+                    highlightIndex = index;
+                    deleteAt(index);
+                    updateView();
+                }
+            }
 
-		};
-	}
+            @Override
+            public void mouseEntered(MouseEvent e) {
+                if (selectionMode == SelectionMode.HOVER && !isEmptyCell(index)) {
+                    highlightIndex = index;
+                    updateView();
+                }
+            }
 
-	public void setSelectionMode(SelectionMode mode) {
-		this.selectionMode = mode;
-		modeLabel.setText("Mode: " + mode);
-	}
+        };
+    }
 
-	public SelectionMode getSelectionMode() {
-		return selectionMode;
+    private boolean isEmptyCell(int idx) {
+        String t = panels[idx].getText();
+        return t == null || t.isEmpty();
+    }
 
-	}
+    public void setSelectionMode(SelectionMode mode) {
+        this.selectionMode = mode;
+        modeLabel.setText("Mode: " + mode + " To change press SPACE");
+    }
 
-	private void updateView() {
-		for (int i=0;i<PANELS_COUNT;i++) {
-			if (i==highlightIndex) {
-				panels[i].setBorder(BorderFactory.createLineBorder(Color.green, 3));
-			}else {
-				panels[i].setBorder(BorderFactory.createLineBorder(Color.blue));
-			}
-		}
-		st.setTitle("Selected index is " + String.valueOf(highlightIndex));
-	}
+    public SelectionMode getSelectionMode() {
+        return selectionMode;
 
-	private void deleteAt(int i) {
-		int col = i % COLS;
-		int row = i / COLS;
+    }
 
-		int bottomRow = -1;
-		for (int idx = col; idx < PANELS_COUNT; idx += COLS) {
-			bottomRow = idx / COLS;
-		}
+    private void updateView() {
+        for (int i = 0; i < PANELS_COUNT; i++) {
+            if (i == highlightIndex && !isEmptyCell(i)) {
+                panels[i].setBorder(BORDER_GREEN);
+            } else {
+                panels[i].setBorder(BORDER_BLUE);
+            }
+        }
 
-		for (int r = row; r < bottomRow; r++) {
-			int from = (r + 1) * COLS + col;
-			int to   = r * COLS + col;
-			panels[to].setText(panels[from].getText());
-		}
-
-		int bottomIndex = bottomRow * COLS + col;
-		panels[bottomIndex].setText("");
-
-		updateView();
-	}
-
-	public void keyLeft() {
-		if (highlightIndex>0)
-			highlightIndex--;
-
-		updateView();
-	}
+        String activeText;
+        if (!isEmptyCell(highlightIndex)) {
+            activeText = panels[highlightIndex].getText();
+        } else {
+            activeText = "-";
+        }
+        window.setTitle("Selected cell: " + activeText);
+    }
 
 
-	public void keyRight() {
-		if (highlightIndex<PANELS_COUNT-1)
-			highlightIndex++;
+    private void deleteAt(int i) {
+        int col = i % COLS;
+        int row = i / COLS;
 
-		updateView();
-	}
+        int bottomRow = -1;
+        for (int idx = col; idx < PANELS_COUNT; idx += COLS) {
+            bottomRow = idx / COLS;
+        }
 
+        for (int r = row; r < bottomRow; r++) {
+            int from = (r + 1) * COLS + col;
+            int to = r * COLS + col;
+            panels[to].setText(panels[from].getText());
+        }
+
+        int bottomIndex = bottomRow * COLS + col;
+        panels[bottomIndex].setText("");
+
+    }
+
+    private void setupKeyListener() {
+        setFocusable(true);
+        addKeyListener(new java.awt.event.KeyAdapter() {
+            @Override
+            public void keyPressed(java.awt.event.KeyEvent e) {
+                switch (e.getKeyCode()) {
+                    case java.awt.event.KeyEvent.VK_LEFT:
+                        keyLeft();
+                        break;
+                    case java.awt.event.KeyEvent.VK_RIGHT:
+                        keyRight();
+                        break;
+                    case java.awt.event.KeyEvent.VK_SPACE:
+                        setSelectionMode(getSelectionMode() == SelectionMode.HOVER ? SelectionMode.CLICK : SelectionMode.HOVER);
+                        break;
+                }
+            }
+        });
+    }
+
+    public void keyLeft() {
+        int i = highlightIndex;
+        while (i > 0) {
+            i--;
+            if (!isEmptyCell(i)) {
+                highlightIndex = i;
+                break;
+            }
+        }
+        updateView();
+    }
+
+    public void keyRight() {
+        int i = highlightIndex;
+        while (i < PANELS_COUNT - 1) {
+            i++;
+            if (!isEmptyCell(i)) {
+                highlightIndex = i;
+                break;
+            }
+        }
+        updateView();
+    }
+
+    private void validateConfig() {
+        if (COLS <= 0 || ROWS <= 0) {
+            throw new IllegalArgumentException("ROWS and COLS must be > 0");
+        }
+        int capacity = ROWS * COLS;
+        if (capacity < PANELS_COUNT) {
+            throw new IllegalArgumentException(
+                    "Invalid configuration: ROWS*COLS = " + ROWS + "x" + COLS + " = " + capacity +
+                            " < PANELS_COUNT = " + PANELS_COUNT + ". Increase ROWS/COLS or decrease PANELS_COUNT."
+            );
+        }
+        if (highlightIndex < 0 || highlightIndex >= PANELS_COUNT) {
+            throw new IllegalArgumentException("highlightIndex out of bounds: 0.." + (PANELS_COUNT - 1));
+        }
+    }
 }
+

--- a/src/test/SelectionMode.java
+++ b/src/test/SelectionMode.java
@@ -1,5 +1,10 @@
 package test;
 
+/**
+ * Selection modes for the grid:
+ * HOVER - highlight on mouse hover, delete on click.
+ * CLICK - highlight and select cell on click, no delete.
+ */
 public enum SelectionMode {
     HOVER,
     CLICK


### PR DESCRIPTION
- HOVER mode: hover highlights; LMB deletes hovered non-empty cell (column shifts up, bottom becomes empty)
- CLICK mode: left-click selects cell and updates header/title
- Never highlight/select empty cells (mouse or keyboard)
- Keyboard LEFT/RIGHT skip empty cells
- updateView: no highlight on empty selection; title shows "-"
- deleteAt: column shift without extra updateView call
- validateConfig(): throws on invalid ROWS/COLS/PANELS_COUNT or highlightIndex
- minor: cleanup and readability tweaks